### PR TITLE
Add cache for Firestore queries

### DIFF
--- a/cumplo_common/__init__.py
+++ b/cumplo_common/__init__.py
@@ -1,3 +1,3 @@
 """A one-stop library that centralizes the core logic and protects the domain of the Cumplo API project."""
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/cumplo_common/database/firestore/__init__.py
+++ b/cumplo_common/database/firestore/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from firebase_admin import credentials, firestore, initialize_app
 
@@ -14,10 +14,21 @@ from .users import UserCollection
 
 
 class Client:
+    _instance: Self | None = None
+    _initialized: bool = False
+
+    def __new__(cls) -> Self:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
     def __init__(self) -> None:
-        initialize_app(credential=credentials.ApplicationDefault(), options={"projectId": PROJECT_ID})
-        self.client: FirestoreClient = firestore.client()
-        self._init_collections()
+        if not self._initialized:
+            initialize_app(credential=credentials.ApplicationDefault(), options={"projectId": PROJECT_ID})
+            self.client: FirestoreClient = firestore.client()
+            self._init_collections()
+            self._initialized = True
 
     def _init_collections(self) -> None:
         """Initialize the collections."""

--- a/cumplo_common/database/firestore/users.py
+++ b/cumplo_common/database/firestore/users.py
@@ -1,11 +1,12 @@
 from collections.abc import Generator
 from logging import getLogger
 
+from cachetools import TTLCache, cached
 from google.cloud.firestore_v1 import Client as FirestoreClient
 from google.cloud.firestore_v1.base_query import FieldFilter
 
 from cumplo_common.models import User
-from cumplo_common.utils.constants import USERS_COLLECTION
+from cumplo_common.utils.constants import CACHE_MAXSIZE, CACHE_TTL, USERS_COLLECTION
 from cumplo_common.utils.text import secure_key
 
 from .channels import ChannelCollection
@@ -13,6 +14,7 @@ from .filters import FilterCollection
 from .notifications import NotificationCollection
 
 logger = getLogger(__name__)
+cache = TTLCache(maxsize=CACHE_MAXSIZE, ttl=CACHE_TTL)
 
 
 class UserCollection:
@@ -20,6 +22,7 @@ class UserCollection:
         self.collection = client.collection(USERS_COLLECTION)
         self.client = client
 
+    @cached(cache=cache)
     def get(self, id_user: str | None = None, api_key: str | None = None) -> User:
         """
         Get a user document.

--- a/cumplo_common/utils/constants.py
+++ b/cumplo_common/utils/constants.py
@@ -26,3 +26,7 @@ DEFAULT_EXPIRATION_MINUTES: int = int(os.getenv("DEFAULT_EXPIRATION_MINUTES", "6
 
 # Validators
 PHONE_NUMBER_REGEX = r"^\+[1-9]\d{1,14}$"
+
+# Cache
+CACHE_MAXSIZE = int(os.getenv("CACHE_MAXSIZE", "1000"))
+CACHE_TTL = int(os.getenv("CACHE_TTL", "600"))

--- a/poetry.lock
+++ b/poetry.lock
@@ -1985,4 +1985,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "8b34436f17bb580f10a04106b08bdda5620f0aadf6dd2045177e014e532f6136"
+content-hash = "e2d7572057d39a91e48e5a03775480fd3a97bcd87d1562d6070e74100b35f150"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cumplo-common"
-version = "1.3.2"
+version = "1.3.3"
 description = "A one-stop library that centralizes the core logic and protects the domain of the Cumplo API project"
 authors = ["Cristobal Sfeir <hello@crisotbalsfeir.com>"]
 packages = [{ include = "cumplo_common" }]
@@ -17,6 +17,7 @@ types-protobuf = "^4.23.0.2"
 fastapi = "^0.109.1"
 ulid-py = "^1.1.0"
 google-cloud-pubsub = "^2.18.4"
+cachetools = "^5.5.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.2"
@@ -50,6 +51,7 @@ module = [
     "starlette.*",
     "google.cloud.pubsub.*",
     "numpy_financial.*",
+    "cachetools.*",
 ]
 ignore_missing_imports = true
 
@@ -77,6 +79,7 @@ ignore = [
     "COM812", # Missing trailing comma in a dictionary
     "ISC001", # Implicit string concatenation
     "CPY001", # Copying notice
+    "B019",   # LRU cache can generate memory leaks (when used without a maxsize)
     # =====
     "PT011",  # ValueError is too broad, set the `match` parameter
     "PT013",  # Incorrect import of `pytest`; use `import pytest` instead


### PR DESCRIPTION
- Define the `Client` class from the Firestore integration as a singleton.
- Add caching for the `users.get()` operation to improve performance.