### PR TITLE
chore: bump version to 1.12.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cumplo-common"
-version = "1.12.7"
+version = "1.12.10"
 description = "A one-stop library that centralizes the core logic and protects the domain of the Cumplo API project"
 authors = ["Cristobal Sfeir <hello@crisotbalsfeir.com>"]
 packages = [{ include = "cumplo_common" }]


### PR DESCRIPTION
Bumps `cumplo-common` to 1.12.10 for publication to the private Artifact Registry PyPI (`cumplo-pypi`), following the merge of #47.

Registry currently has up to 1.12.9; master's pyproject was stale at 1.12.7. Versions are immutable, so this releases 1.12.10.