### PR TITLE
ci: automate build, version-safety & publish to Artifact Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Lint, type-check & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "2.4.1"
+          virtualenvs-in-project: true
+
+      - name: Cache virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Ruff lint
+        run: poetry run ruff check .
+
+      - name: Ruff format check
+        run: poetry run ruff format --check .
+
+      - name: Mypy
+        run: poetry run mypy --config-file pyproject.toml .
+
+      - name: Pytest
+        run: poetry run pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create tags & GitHub Releases
+  id-token: write # mint the OIDC token for Workload Identity Federation
+
+jobs:
+  publish:
+    name: Build & publish to Artifact Registry
+    runs-on: ubuntu-latest
+    env:
+      AR_LOCATION: us-central1
+      AR_PROJECT: cumplo-scraper
+      AR_REPOSITORY: cumplo-pypi
+      PACKAGE: cumplo-common
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need full history/tags for the release
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "2.4.1"
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Read version
+        id: version
+        run: echo "value=$(poetry version -s)" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.PUBLISH_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Check whether this version is already published
+        id: check
+        run: |
+          if gcloud artifacts versions describe "${{ steps.version.outputs.value }}" \
+               --package="$PACKAGE" --repository="$AR_REPOSITORY" \
+               --location="$AR_LOCATION" --project="$AR_PROJECT" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.version.outputs.value }} already published — nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        if: steps.check.outputs.exists == 'false'
+        run: make build
+
+      - name: Publish to Artifact Registry
+        if: steps.check.outputs.exists == 'false'
+        env:
+          TWINE_USERNAME: oauth2accesstoken
+        run: |
+          TWINE_PASSWORD="$(gcloud auth print-access-token)" make publish
+
+      - name: Tag & GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.value }}" \
+            --title "${{ steps.version.outputs.value }}" \
+            --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+-include .env
 export
 
 # Runs linters
@@ -7,6 +7,21 @@ lint:
 	@ruff check --fix
 	@ruff format
 	@mypy --config-file pyproject.toml .
+
+# Runs the same quality gates as CI, non-mutating (local pre-flight)
+.PHONY: check
+check:
+	@poetry run ruff check .
+	@poetry run ruff format --check .
+	@poetry run mypy --config-file pyproject.toml .
+	@poetry run pytest
+
+# Bumps the version (single source of truth: pyproject.toml). Usage: make bump PART=patch|minor|major
+PART ?= patch
+.PHONY: bump
+bump:
+	@poetry version $(PART)
+	@echo "Bumped to $$(poetry version -s) — commit, open a PR; publish happens automatically on merge to master."
 
 
 # Builds the library

--- a/cumplo_common/__init__.py
+++ b/cumplo_common/__init__.py
@@ -1,3 +1,8 @@
 """A one-stop library that centralizes the core logic and protects the domain of the Cumplo API project."""
 
-__version__ = "1.12.7"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("cumplo-common")
+except PackageNotFoundError:  # not installed (e.g. raw source checkout)
+    __version__ = "0.0.0"


### PR DESCRIPTION
## Summary
Moves `cumplo-common` releases into GitHub Actions so a release is just **"bump the version in your PR; on merge, CI publishes it"** — with the `not-cumplo-audit-gate` ruleset left fully intact (no bot pushes to master, no bypass actor added) and **keyless** auth (Workload Identity Federation, no stored keys).

Directly fixes the two problems hit while publishing 1.12.10: version drift across `pyproject.toml` / `__init__.py` / tags, and manual toolchain fragility.

## What's included
**`.github/workflows/ci.yml`** — on every PR (and push to master): `ruff check`, `ruff format --check`, `mypy`, `pytest`. Python 3.12 + Poetry 2.4.1, venv cached on `poetry.lock`.

**`.github/workflows/release.yml`** — on push to master:
1. Auth to GCP via WIF (repo-scoped OIDC → `cumplo-pypi` SA).
2. Read version from `pyproject.toml`.
3. **Idempotency gate:** if that version already exists in `cumplo-pypi`, no-op. Otherwise build, publish (`make publish` with a short-lived access token — no keyring plugin), and create the matching tag + GitHub Release.

**`cumplo_common/__init__.py`** — `__version__` now derives from installed package metadata, so `pyproject.toml` is the single source of truth (no more `__init__` drift).

**`Makefile`** — `-include .env` (so build/publish work in CI without a `.env`); `make bump PART=patch|minor|major` (release helper); `make check` (local mirror of the CI gates).

## Infra provisioned out-of-band (not in this diff)
- WIF pool `github` + OIDC provider `cumplo-common` (attribute-condition scoped to **this repo only**), bound to impersonate `cumplo-pypi`.
- Repo variables `WIF_PROVIDER` and `PUBLISH_SA`.

## Verification
- CI gates pass locally (`make check`: ruff/format/mypy clean, 23 tests pass); `__version__` resolves to `1.12.10`.
- On merge, `release.yml` will see `1.12.10` already published and safely no-op — exercising the idempotency gate before any real release.

## Follow-ups (not in this PR)
- Make the CI `quality` check **required** on the ruleset once it's green here.
- Optional: reduce `cumplo-pypi` from `artifactregistry.admin` → `writer`; align devcontainer Poetry (1.8.2) with CI (2.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)