### PR TITLE
chore: harden publish SA, align devcontainer Poetry, document CI/CD

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "dockerfile": "Dockerfile",
     "args": {
       "WORKSPACE_FOLDER": "${localWorkspaceFolderBasename}",
-      "POETRY_VERSION": "1.8.2"
+      "POETRY_VERSION": "2.4.1"
     }
   },
   "customizations": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# cumplo-common
+
+## Overview
+Shared domain library that centralizes core logic for the Cumplo API project. Published as a
+private package to Google Cloud Artifact Registry and consumed by the Cumplo Cloud Run
+services (orchestrator, herald, spotter, tailor, accountant).
+
+## Build & Test
+- Install deps: `poetry install`
+- Run the full CI gate locally (non-mutating): `make check`
+  — equivalent to `poetry run ruff check .`, `ruff format --check .`, `mypy`, `pytest`
+- Auto-fix lint + format: `make lint`
+- Build artifacts: `make build`
+
+Python 3.12, Poetry 2.4.x. Tests need no secrets — `tests/conftest.py` injects a test Fernet key.
+
+## Releasing (CI/CD)
+Releases are automated. **The version lives in exactly one place: `pyproject.toml`.**
+`cumplo_common/__init__.py` derives `__version__` from installed metadata — never hardcode it.
+
+To cut a release:
+1. On your branch: `make bump PART=patch|minor|major` (bumps `pyproject.toml`).
+2. Open a PR, get it reviewed and merged (see Git workflow below).
+3. On merge to `master`, `.github/workflows/release.yml` builds and publishes **only if that
+   version isn't already in the registry** (idempotent — non-release merges safely no-op),
+   then creates the matching bare-numeric git tag + GitHub Release.
+
+- `.github/workflows/ci.yml` runs ruff / format / mypy / pytest on every PR (required check).
+- Auth to Artifact Registry is **keyless** via Workload Identity Federation (repo-scoped OIDC
+  → `cumplo-pypi` service account). No keys or secrets are stored in GitHub.
+- Registry: `cumplo-pypi` (Python) in `us-central1`, project `cumplo-scraper`.
+
+## Git workflow
+- Branch prefixes: `feat/`, `fix/`, `chore/`, `ci/`. Conventional-commit subjects (`feat:`, `fix:`, …).
+- `master` is protected by the `not-cumplo-audit-gate` ruleset: every change needs a **PR +
+  code-owner review** (`@cnsfeir-reviewer`); only org admins can bypass. **Never push to
+  `master` directly** — it is rejected. Open a PR.
+
+## Gotchas
+- **Published versions are immutable.** Artifact Registry refuses to overwrite an existing
+  version — always `make bump` before releasing; you can't republish a number.
+- **twine must stay ≥ 6.1.** Poetry 2.x emits Metadata-Version 2.4 wheels that older twine
+  can't parse (fails with a misleading "missing Name, Version"). Don't downgrade it.
+- **Manual publish is rarely needed** (CI handles it). If you must: `gcloud auth
+  application-default login`, then `make build && make publish`.
+- The devcontainer builds with a gitignored `cumplo_pypi_credentials.json` SA key to *pull*
+  the package locally; CI does not use it (WIF instead).
+
+## Before committing
+- [ ] `make check` passes
+- [ ] Version bumped (`make bump`) if this change should trigger a release
+- [ ] No secrets or credential files committed


### PR DESCRIPTION
Follow-up to #50. Two repo changes plus one out-of-band infra hardening.

## Repo changes
- **`.devcontainer/devcontainer.json`** — bump Poetry `1.8.2` → `2.4.1` to match CI and local publishing. `poetry.lock` is now in Poetry 2.x format, so the old 1.8.2 devcontainer could misread it; aligning versions makes local dev reproduce CI exactly.
- **`CLAUDE.md`** (new) — concise project guide documenting the automated release flow (`make bump` → PR → publish-on-merge), keyless WIF auth, the `not-cumplo-audit-gate` ruleset, the single-source-of-truth version rule, and the key gotchas (immutable versions, twine ≥6.1). Written to the Claude Code best-practices guidelines (~80 lines, only non-derivable facts).

## Out-of-band infra hardening (no file in this diff)
The **`cumplo-pypi`** service account was over-privileged with project-wide `roles/artifactregistry.admin` (could delete/re-permission *every* AR repo in the project). Reduced to least privilege:
- Granted `roles/artifactregistry.writer` **scoped to the `cumplo-pypi` repo only**.
- Removed the project-wide `roles/artifactregistry.admin`.

Verified the SA is not the runtime identity of any Cloud Run service or Cloud Function, so nothing depends on the broader grant. The WIF impersonation binding is unaffected — CI still publishes (proven by the no-op release run on #50's merge).

**Revert if ever needed:** `gcloud projects add-iam-policy-binding cumplo-scraper --member=serviceAccount:cumplo-pypi@cumplo-scraper.iam.gserviceaccount.com --role=roles/artifactregistry.admin`