### PR TITLE
chore: Adopt standard Python tooling (Ruff ALL, basedpyright, docformatter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          # Pinned to 3.12: docformatter 1.7.8 crashes on all Python 3.13.x
-          # (tokenize.untokenize regression; upstream fix not yet released as of 2026-07-19).
-          # Restore "3.13" once docformatter 1.7.9 ships with the fix (PyCQA/docformatter#360).
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -34,13 +31,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
-
-      - name: Refresh lock file metadata
-        # Regenerates lock file metadata (python-versions, content-hash) to match
-        # the current pyproject.toml without changing resolved package versions.
-        # Remove this step once the Python constraint is restored to 3.13.
-        run: poetry lock --no-interaction
+          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
 
+      - name: Refresh lock file metadata
+        # Regenerates only metadata (python-versions, content-hash) to match the
+        # current pyproject.toml; package versions are unchanged (--no-update).
+        # Remove this step once the Python constraint is back on 3.13.
+        run: poetry lock --no-update --no-interaction
+
       - name: Install dependencies
         run: poetry install --no-interaction
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          # Pinned to 3.13.5: docformatter 1.7.8 crashes on 3.13.6+ (tokenize.untokenize
+          # regression, upstream issue PyCQA/docformatter#347, no fix released yet).
+          python-version: "3.13.5"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -31,19 +31,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
+          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction
 
-      - name: Ruff lint
-        run: poetry run ruff check .
-
-      - name: Ruff format check
-        run: poetry run ruff format --check .
-
-      - name: Mypy
-        run: poetry run mypy --config-file pyproject.toml .
+      - name: Lint
+        run: make lint
 
       - name: Pytest
         run: poetry run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
           key: venv-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
 
       - name: Refresh lock file metadata
-        # Regenerates only metadata (python-versions, content-hash) to match the
-        # current pyproject.toml; package versions are unchanged (--no-update).
-        # Remove this step once the Python constraint is back on 3.13.
-        run: poetry lock --no-update --no-interaction
+        # Regenerates lock file metadata (python-versions, content-hash) to match
+        # the current pyproject.toml without changing resolved package versions.
+        # Remove this step once the Python constraint is restored to 3.13.
+        run: poetry lock --no-interaction
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          # Pinned to 3.13.5: docformatter 1.7.8 crashes on 3.13.6+ (tokenize.untokenize
-          # regression, upstream issue PyCQA/docformatter#347, no fix released yet).
-          python-version: "3.13.5"
+          # Pinned to 3.12: docformatter 1.7.8 crashes on all Python 3.13.x
+          # (tokenize.untokenize regression; upstream fix not yet released as of 2026-07-19).
+          # Restore "3.13" once docformatter 1.7.9 ships with the fix (PyCQA/docformatter#360).
+          python-version: "3.12"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -33,7 +34,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('poetry.lock') }}
+          key: venv-${{ runner.os }}-py3.12-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,12 +7,13 @@ services (orchestrator, herald, spotter, tailor, accountant).
 
 ## Build & Test
 - Install deps: `poetry install`
-- Run the full CI gate locally (non-mutating): `make check`
-  — equivalent to `poetry run ruff check .`, `ruff format --check .`, `mypy`, `pytest`
-- Auto-fix lint + format: `make lint`
+- Run tests: `poetry run pytest`
+- Auto-fix lint + format: `make format`
+- Verify code quality (CI gate): `make lint`
+- Full local CI simulation (lint + tests): `make check`
 - Build artifacts: `make build`
 
-Python 3.12, Poetry 2.4.x. Tests need no secrets — `tests/conftest.py` injects a test Fernet key.
+Python 3.13, Poetry 2.4.x. Tests need no secrets — `tests/conftest.py` injects a test Fernet key.
 
 ## Releasing (CI/CD)
 Releases are automated. **The version lives in exactly one place: `pyproject.toml`.**
@@ -25,7 +26,7 @@ To cut a release:
    version isn't already in the registry** (idempotent — non-release merges safely no-op),
    then creates the matching bare-numeric git tag + GitHub Release.
 
-- `.github/workflows/ci.yml` runs ruff / format / mypy / pytest on every PR (required check).
+- `.github/workflows/ci.yml` runs `make lint` (ruff / basedpyright / docformatter) + pytest on every PR (required check).
 - Auth to Artifact Registry is **keyless** via Workload Identity Federation (repo-scoped OIDC
   → `cumplo-pypi` service account). No keys or secrets are stored in GitHub.
 - Registry: `cumplo-pypi` (Python) in `us-central1`, project `cumplo-scraper`.
@@ -47,6 +48,6 @@ To cut a release:
   the package locally; CI does not use it (WIF instead).
 
 ## Before committing
-- [ ] `make check` passes
-- [ ] Version bumped (`make bump`) if this change should trigger a release
-- [ ] No secrets or credential files committed
+- [ ] Run `make format`, then `make lint` and ensure it passes.
+- [ ] Version bumped (`make bump`) if this change should trigger a release.
+- [ ] No secrets or credential files committed.

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,25 @@
 -include .env
 export
 
-# Runs linters
+# Verifies code quality — check-only, no fixes (same command as CI)
 .PHONY: lint
 lint:
-	@ruff check --fix
-	@ruff format
-	@mypy --config-file pyproject.toml .
+	@poetry run ruff check --no-fix .
+	@poetry run ruff format --check .
+	@poetry run basedpyright
+	@poetry run docformatter --check --recursive .
 
-# Runs the same quality gates as CI, non-mutating (local pre-flight)
+# Applies all auto-fixes (ruff + docformatter)
+.PHONY: format
+format:
+	@poetry run ruff format .
+	@poetry run ruff check --fix .
+	@poetry run docformatter --in-place --recursive .
+
+# Runs the full local CI gate (lint + tests)
 .PHONY: check
 check:
-	@poetry run ruff check .
-	@poetry run ruff format --check .
-	@poetry run mypy --config-file pyproject.toml .
+	@make lint
 	@poetry run pytest
 
 # Bumps the version (single source of truth: pyproject.toml). Usage: make bump PART=patch|minor|major

--- a/cumplo_common/database/firestore/client.py
+++ b/cumplo_common/database/firestore/client.py
@@ -20,6 +20,7 @@ class Client:
     client: firestore.Client  # pyright: ignore[reportAttributeAccessIssue]
 
     def __new__(cls) -> Self:
+        """Return the singleton instance, creating it if necessary."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._initialized = False

--- a/cumplo_common/database/firestore/client.py
+++ b/cumplo_common/database/firestore/client.py
@@ -1,3 +1,5 @@
+"""Firestore client singleton for the Cumplo database."""
+
 from typing import Self
 
 from firebase_admin import credentials, firestore, initialize_app
@@ -8,17 +10,19 @@ from .users import DisabledCollection, UserCollection
 
 
 class Client:
+    """Singleton Firestore client that provides access to user and disabled collections."""
+
     _instance: Self | None = None
     _initialized: bool = False
 
     users: UserCollection
     disabled: DisabledCollection
-    client: firestore.Client
+    client: firestore.Client  # pyright: ignore[reportAttributeAccessIssue]
 
     def __new__(cls) -> Self:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-            cls._instance._initialized = False  # noqa: SLF001
+            cls._instance._initialized = False
         return cls._instance
 
     def __init__(self) -> None:

--- a/cumplo_common/database/firestore/users.py
+++ b/cumplo_common/database/firestore/users.py
@@ -1,3 +1,5 @@
+"""Firestore user and disabled-user collection accessors."""
+
 from collections.abc import Generator
 from logging import getLogger
 from typing import Any
@@ -14,6 +16,8 @@ logger = getLogger(__name__)
 
 
 class UserCollection:
+    """Firestore collection accessor for active users."""
+
     collection: CollectionReference
     keys: CollectionReference
     emails: CollectionReference
@@ -157,6 +161,8 @@ class UserCollection:
 
 
 class DisabledCollection(UserCollection):
+    """Firestore collection accessor for disabled users."""
+
     def __init__(self, client: FirestoreClient, *args: Any, **kwargs: Any) -> None:
         super().__init__(client, *args, **kwargs)
         self.collection = client.collection(DISABLED_COLLECTION)

--- a/cumplo_common/database/firestore/users.py
+++ b/cumplo_common/database/firestore/users.py
@@ -76,7 +76,7 @@ class UserCollection:
 
         return User(id=ulid.parse(user.id), **data)
 
-    def list(self) -> Generator[User, None, None]:
+    def list(self) -> Generator[User]:
         """
         List all users.
 

--- a/cumplo_common/dependencies/authentication.py
+++ b/cumplo_common/dependencies/authentication.py
@@ -1,3 +1,5 @@
+"""FastAPI dependency for authenticating incoming requests."""
+
 from http import HTTPStatus
 from logging import getLogger
 from typing import Annotated

--- a/cumplo_common/dependencies/authorization.py
+++ b/cumplo_common/dependencies/authorization.py
@@ -1,3 +1,5 @@
+"""FastAPI dependency for authorizing admin-only requests."""
+
 from http import HTTPStatus
 
 from fastapi.exceptions import HTTPException

--- a/cumplo_common/integrations/cloud_pubsub.py
+++ b/cumplo_common/integrations/cloud_pubsub.py
@@ -1,3 +1,5 @@
+"""Integration wrapper for Google Cloud Pub/Sub."""
+
 import json
 
 from google.cloud.pubsub import PublisherClient

--- a/cumplo_common/integrations/cloud_tasks.py
+++ b/cumplo_common/integrations/cloud_tasks.py
@@ -1,3 +1,5 @@
+"""Integration wrapper for Google Cloud Tasks."""
+
 import json
 from datetime import datetime
 from typing import Annotated

--- a/cumplo_common/integrations/gmail.py
+++ b/cumplo_common/integrations/gmail.py
@@ -7,6 +7,7 @@ from email.mime.text import MIMEText
 from logging import getLogger
 from operator import itemgetter
 from pathlib import Path
+from typing import Any
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -48,7 +49,7 @@ class Gmail:
     """Integration with Gmail API."""
 
     @classmethod
-    def _authenticate(cls) -> build:
+    def _authenticate(cls) -> Any:
         """Authenticate with Gmail API."""
         credentials = service_account.Credentials.from_service_account_info(
             info=GMAIL_CREDENTIALS,
@@ -58,7 +59,7 @@ class Gmail:
         return build(serviceName="gmail", version="v1", credentials=credentials)
 
     @classmethod
-    def _get_message(cls, service: build, message_id: str) -> Message:
+    def _get_message(cls, service: Any, message_id: str) -> Message:
         """Get a message from Gmail."""
         message = service.users().messages().get(userId=GMAIL_USER_ID, id=message_id).execute()
         return Message(message)

--- a/cumplo_common/integrations/gmail.py
+++ b/cumplo_common/integrations/gmail.py
@@ -1,3 +1,5 @@
+"""Integration wrapper for the Gmail API."""
+
 import base64
 import re
 from collections import UserDict

--- a/cumplo_common/middlewares/pubsub.py
+++ b/cumplo_common/middlewares/pubsub.py
@@ -1,3 +1,5 @@
+"""FastAPI middleware for decoding Pub/Sub push messages."""
+
 import json
 from base64 import b64decode
 from collections.abc import Awaitable, Callable
@@ -32,6 +34,8 @@ class PubSubEvent(BaseModel):
 
 
 class PubSubMiddleware(BaseHTTPMiddleware):
+    """Middleware that parses Pub/Sub push payloads and stores the event on request state."""
+
     async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:  # noqa: PLR6301
         """
         Middleware to handle PubSub messages.

--- a/cumplo_common/middlewares/pubsub.py
+++ b/cumplo_common/middlewares/pubsub.py
@@ -32,8 +32,7 @@ class PubSubEvent(BaseModel):
 
 
 class PubSubMiddleware(BaseHTTPMiddleware):
-    @staticmethod
-    async def dispatch(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:  # noqa: PLR6301
         """
         Middleware to handle PubSub messages.
 
@@ -55,6 +54,6 @@ class PubSubMiddleware(BaseHTTPMiddleware):
             logger.debug("Received a non-PubSub request")
 
         else:
-            request._body = b64decode(event.message.data)  # noqa: SLF001
+            request._body = b64decode(event.message.data)
 
         return await call_next(request)

--- a/cumplo_common/models/base_model.py
+++ b/cumplo_common/models/base_model.py
@@ -1,3 +1,5 @@
+"""Abstract base model shared across all domain models."""
+
 from abc import ABC
 from json import loads
 from typing import Any
@@ -19,15 +21,19 @@ class BaseModel(pydantic.BaseModel, ABC):
     )
 
     def __hash__(self) -> int:
+        """Return hash based on non-id field values."""
         return hash(self.model_dump_json(exclude={"id"}, exclude_none=True))
 
     def __str__(self) -> str:
+        """Return JSON string representation."""
         return self.model_dump_json(exclude_none=True)
 
     def __repr__(self) -> str:
+        """Return JSON string representation."""
         return self.model_dump_json(exclude_none=True)
 
     def __eq__(self, other: object) -> bool:
+        """Return True if hashes match."""
         return self.__hash__() == other.__hash__()
 
     def json(self, *args: Any, **kwargs: Any) -> dict:  # type: ignore[override]

--- a/cumplo_common/models/borrower.py
+++ b/cumplo_common/models/borrower.py
@@ -1,3 +1,5 @@
+"""Borrower domain model."""
+
 from datetime import datetime
 
 from pydantic import Field
@@ -7,6 +9,8 @@ from .portfolio import Portfolio
 
 
 class Borrower(BaseModel):
+    """Borrower profile for a funding request."""
+
     id: int | None = Field(None)
     name: str | None = Field(None)
     economic_sector: str | None = Field(None)

--- a/cumplo_common/models/channel.py
+++ b/cumplo_common/models/channel.py
@@ -59,7 +59,7 @@ class ChannelConfiguration(BaseModel, ABC):
 
 
 class IFTTTConfiguration(ChannelConfiguration):
-    type_: Literal[ChannelType.IFTTT] = ChannelType.IFTTT
+    type_: Literal[ChannelType.IFTTT] = ChannelType.IFTTT  # pyright: ignore[reportIncompatibleVariableOverride]
     key: str = Field(...)
     event: str = Field(...)
 
@@ -81,13 +81,13 @@ class IFTTTConfiguration(ChannelConfiguration):
 
 
 class WhatsappConfiguration(ChannelConfiguration):
-    type_: Literal[ChannelType.WHATSAPP] = ChannelType.WHATSAPP
+    type_: Literal[ChannelType.WHATSAPP] = ChannelType.WHATSAPP  # pyright: ignore[reportIncompatibleVariableOverride]
     phone_number: str = Field(pattern=PHONE_NUMBER_REGEX)
 
 
 class WebhookConfiguration(ChannelConfiguration):
     enabled_events: set[PublicEvent] | ALL_EVENTS_TYPE = Field(default_factory=set)
-    type_: Literal[ChannelType.WEBHOOK] = ChannelType.WEBHOOK
+    type_: Literal[ChannelType.WEBHOOK] = ChannelType.WEBHOOK  # pyright: ignore[reportIncompatibleVariableOverride]
     url: str = Field(..., max_length=2000)
 
     @field_validator("url", mode="before")

--- a/cumplo_common/models/channel.py
+++ b/cumplo_common/models/channel.py
@@ -1,3 +1,5 @@
+"""Channel configuration models for user notification channels."""
+
 import ipaddress
 from abc import ABC
 from typing import Any, Literal, Self
@@ -17,6 +19,8 @@ ALL_EVENTS: ALL_EVENTS_TYPE = "all"
 
 
 class ChannelType(StrEnum):
+    """Supported notification channel types."""
+
     WHATSAPP = "WHATSAPP"
     WEBHOOK = "WEBHOOK"
     IFTTT = "IFTTT"
@@ -26,7 +30,7 @@ class ChannelConfiguration(BaseModel, ABC):
     """Base class for channel configuration."""
 
     id: ulid.ULID = Field(...)
-    enabled: bool = Field(True)
+    enabled: bool = Field(default=True)
     type_: ChannelType = Field(...)
     enabled_events: set[PublicEvent] | ALL_EVENTS_TYPE = Field(ALL_EVENTS)
     disabled_events: set[PublicEvent] = Field(default_factory=set)
@@ -59,6 +63,8 @@ class ChannelConfiguration(BaseModel, ABC):
 
 
 class IFTTTConfiguration(ChannelConfiguration):
+    """IFTTT webhook channel configuration."""
+
     type_: Literal[ChannelType.IFTTT] = ChannelType.IFTTT  # pyright: ignore[reportIncompatibleVariableOverride]
     key: str = Field(...)
     event: str = Field(...)
@@ -81,11 +87,15 @@ class IFTTTConfiguration(ChannelConfiguration):
 
 
 class WhatsappConfiguration(ChannelConfiguration):
+    """WhatsApp channel configuration."""
+
     type_: Literal[ChannelType.WHATSAPP] = ChannelType.WHATSAPP  # pyright: ignore[reportIncompatibleVariableOverride]
     phone_number: str = Field(pattern=PHONE_NUMBER_REGEX)
 
 
 class WebhookConfiguration(ChannelConfiguration):
+    """Webhook channel configuration."""
+
     enabled_events: set[PublicEvent] | ALL_EVENTS_TYPE = Field(default_factory=set)
     type_: Literal[ChannelType.WEBHOOK] = ChannelType.WEBHOOK  # pyright: ignore[reportIncompatibleVariableOverride]
     url: str = Field(..., max_length=2000)

--- a/cumplo_common/models/credentials.py
+++ b/cumplo_common/models/credentials.py
@@ -1,3 +1,5 @@
+"""User credentials model with encrypted password handling."""
+
 import re
 from typing import Any
 
@@ -10,6 +12,8 @@ from .base_model import BaseModel
 
 
 class Credentials(BaseModel):
+    """Cumplo user credentials with encrypted password storage."""
+
     email: str = Field(pattern=r"^[\w\.\-\+]+@([\w\-]+\.)+[\w\-]{2,4}$")
     password: str = Field()
     user_id: str = Field(...)

--- a/cumplo_common/models/credit.py
+++ b/cumplo_common/models/credit.py
@@ -1,7 +1,11 @@
+"""Credit type enumeration."""
+
 from .utils import StrEnum
 
 
 class CreditType(StrEnum):
+    """Supported credit types for funding requests."""
+
     HUD_SUBSIDY = "HOUSING & URBAN DEVELOPMENT SUBSIDY"
     TREASURY_SUBSIDY = "TREASURY SUBSIDY"
     WORKING_CAPITAL = "WORKING CAPITAL"

--- a/cumplo_common/models/currency.py
+++ b/cumplo_common/models/currency.py
@@ -1,7 +1,11 @@
+"""Currency enumeration."""
+
 from .utils import StrEnum
 
 
 class Currency(StrEnum):
+    """Supported currency codes."""
+
     CLP = "CLP"
     MXN = "MXN"
     PES = "PES"

--- a/cumplo_common/models/debtor.py
+++ b/cumplo_common/models/debtor.py
@@ -1,3 +1,5 @@
+"""Debtor domain model."""
+
 from datetime import datetime
 from decimal import Decimal
 
@@ -8,6 +10,8 @@ from .portfolio import Portfolio
 
 
 class Debtor(BaseModel):
+    """Debtor profile for a funding request."""
+
     share: Decimal = Field(...)
     name: str | None = Field(None)
     economic_sector: str | None = Field(None)

--- a/cumplo_common/models/event_private.py
+++ b/cumplo_common/models/event_private.py
@@ -1,3 +1,5 @@
+"""Internal (private) event definitions."""
+
 from cumplo_common.models.funding_request import FundingRequest
 from cumplo_common.models.investment import Investment
 from cumplo_common.models.movement import Movement

--- a/cumplo_common/models/event_public.py
+++ b/cumplo_common/models/event_public.py
@@ -1,3 +1,5 @@
+"""Public event definitions."""
+
 from cumplo_common.models.funding_request import FundingRequest
 
 from .utils import Event

--- a/cumplo_common/models/filter_configuration.py
+++ b/cumplo_common/models/filter_configuration.py
@@ -1,3 +1,5 @@
+"""Filter configuration models for funding-request filtering."""
+
 from decimal import Decimal
 from json import loads
 from typing import Any, Self
@@ -51,7 +53,7 @@ class FilterConfiguration(BaseModel):
     minimum_irr: Decimal | None = Field(None, ge=0)
     minimum_monthly_profit_rate: Decimal | None = Field(None, ge=0)
 
-    ignore_dicom: bool = Field(False)
+    ignore_dicom: bool = Field(default=False)
     maximum_debtors: PositiveInt | None = Field(None)
     portfolio: list[PortfolioFilterConfiguration] = Field(default_factory=list)
 

--- a/cumplo_common/models/funding_request.py
+++ b/cumplo_common/models/funding_request.py
@@ -1,3 +1,5 @@
+"""Funding request domain model with computed financial metrics."""
+
 from decimal import Decimal
 from functools import cached_property
 from math import ceil
@@ -16,19 +18,26 @@ from .utils import StrEnum
 
 
 class DurationUnit(StrEnum):
+    """Unit for expressing a funding-request duration."""
+
     MONTH = "MONTH"
     DAY = "DAY"
 
 
 class Duration(BaseModel):
+    """Duration value with its unit for a funding request."""
+
     unit: DurationUnit = Field(...)
     value: int = Field(...)
 
     def __str__(self) -> str:
+        """Return a human-readable duration string."""
         return f"{self.value} {self.unit.lower()}s"
 
 
 class FundingRequest(BaseModel):
+    """Full funding-request record with computed financial metrics."""
+
     id: int = Field(...)
     amount: int = Field(...)
     irr: Decimal = Field(...)

--- a/cumplo_common/models/investment.py
+++ b/cumplo_common/models/investment.py
@@ -1,3 +1,5 @@
+"""Investment domain model."""
+
 from datetime import datetime
 
 from pydantic import Field
@@ -8,6 +10,8 @@ from .funding_request import Duration
 
 
 class Investment(BaseModel):
+    """Single investment record on a funding request."""
+
     id: int = Field(...)
     id_funding_request: int = Field(...)
     credit_type: CreditType = Field(...)

--- a/cumplo_common/models/movement.py
+++ b/cumplo_common/models/movement.py
@@ -1,4 +1,7 @@
+"""Movement domain model."""
+
 from pydantic import BaseModel
 
 
-class Movement(BaseModel): ...
+class Movement(BaseModel):
+    """Account movement (deposit, withdrawal, or fee)."""

--- a/cumplo_common/models/notification.py
+++ b/cumplo_common/models/notification.py
@@ -1,3 +1,5 @@
+"""Notification domain model."""
+
 from datetime import datetime
 from re import fullmatch
 from typing import Self
@@ -12,6 +14,8 @@ from .event_public import PublicEvent
 
 
 class Notification(BaseModel):
+    """Notification sent to a user for a recurring event."""
+
     id: str = Field(...)
     event: PublicEvent = Field(...)
     date: datetime = Field(...)

--- a/cumplo_common/models/portfolio.py
+++ b/cumplo_common/models/portfolio.py
@@ -1,3 +1,5 @@
+"""Portfolio domain models with grouped category breakdowns."""
+
 from decimal import Decimal
 from functools import cached_property
 
@@ -40,6 +42,8 @@ class PortfolioGroup(BaseModel):
 
 
 class Portfolio(BaseModel):
+    """Aggregated portfolio breakdown by category."""
+
     cured: PortfolioGroup = Field(...)
     active: PortfolioGroup = Field(...)
     overdue: PortfolioGroup = Field(...)

--- a/cumplo_common/models/session.py
+++ b/cumplo_common/models/session.py
@@ -1,3 +1,5 @@
+"""Session domain model."""
+
 from datetime import datetime
 
 import arrow
@@ -9,6 +11,8 @@ from .base_model import BaseModel
 
 
 class Session(BaseModel):
+    """Authenticated session token with expiry."""
+
     token: str = Field(...)
     date: datetime = Field(default_factory=lambda: arrow.utcnow().datetime)
 

--- a/cumplo_common/models/simulation.py
+++ b/cumplo_common/models/simulation.py
@@ -1,3 +1,5 @@
+"""Simulation and installment models for funding-request projections."""
+
 from datetime import datetime
 from decimal import Decimal
 from functools import cached_property
@@ -10,6 +12,8 @@ from .base_model import BaseModel
 
 
 class SimulationInstallment(BaseModel):
+    """Single installment in a funding-request simulation."""
+
     amount: int = Field(...)
     capital: int = Field(...)
     exit_fee: int = Field(...)
@@ -18,6 +22,8 @@ class SimulationInstallment(BaseModel):
 
 
 class Simulation(BaseModel):
+    """Simulation result for a funding request."""
+
     exit_fee: int = Field(...)
     upfront_fee: int = Field(...)
     net_returns: int = Field(...)

--- a/cumplo_common/models/user.py
+++ b/cumplo_common/models/user.py
@@ -1,3 +1,5 @@
+"""User domain model with balance, portfolio, and session sub-models."""
+
 # mypy: disable-error-code="misc, call-overload"
 
 
@@ -25,6 +27,8 @@ from .utils import EventModel
 
 
 class Balance(BaseModel):
+    """User cash balance with expiry tracking."""
+
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     amount: int = Field()
 
@@ -35,6 +39,8 @@ class Balance(BaseModel):
 
 
 class InvestmentPortfolio(BaseModel):
+    """Cached snapshot of a user's investments."""
+
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     investments: dict[int, Investment] = Field(default_factory=dict)
 
@@ -45,10 +51,12 @@ class InvestmentPortfolio(BaseModel):
 
 
 class User(BaseModel):
+    """Cumplo platform user with preferences, credentials, and portfolio."""
+
     id: ulid.ULID = Field(...)
     api_key: str = Field(...)
     email: str = Field(...)
-    is_admin: bool = Field(False)
+    is_admin: bool = Field(default=False)
     name: str = Field(..., max_length=30)
     credentials: Credentials | None = Field(None)
     expiration_minutes: PositiveInt = Field(DEFAULT_EXPIRATION_MINUTES)

--- a/cumplo_common/models/user.py
+++ b/cumplo_common/models/user.py
@@ -2,7 +2,6 @@
 
 # mypy: disable-error-code="misc, call-overload"
 
-
 from datetime import UTC, datetime
 
 import arrow

--- a/cumplo_common/models/utils.py
+++ b/cumplo_common/models/utils.py
@@ -1,3 +1,5 @@
+"""Shared base enum and event utilities."""
+
 import enum
 from collections.abc import Generator
 from typing import Self
@@ -6,6 +8,8 @@ from pydantic import BaseModel
 
 
 class StrEnum(enum.StrEnum):
+    """Case-insensitive string enum base class."""
+
     @classmethod
     def _missing_(cls, value: object) -> Self | None:
         """Return the enum member case insensitively."""
@@ -33,10 +37,14 @@ class StrEnum(enum.StrEnum):
 
 
 class EventModel(BaseModel):
+    """Minimal model carrying an integer ID used by events."""
+
     id: int
 
 
 class Event(StrEnum):
+    """Base class for domain events, associating a string value with an EventModel type."""
+
     _name_: str
     model: type[BaseModel]
     is_recurring: bool

--- a/cumplo_common/models/utils.py
+++ b/cumplo_common/models/utils.py
@@ -21,7 +21,7 @@ class StrEnum(enum.StrEnum):
         return any(value.casefold() == item.name.casefold() for item in cls)
 
     @classmethod
-    def members(cls) -> Generator[Self, None, None]:
+    def members(cls) -> Generator[Self]:
         """
         Yield the enum members.
 
@@ -38,10 +38,10 @@ class EventModel(BaseModel):
 
 class Event(StrEnum):
     _name_: str
-    model: type[EventModel]
+    model: type[BaseModel]
     is_recurring: bool
 
-    def __new__(cls, value: str, model: type[EventModel], is_recurring: bool = False) -> Self:  # noqa: FBT001, FBT002
+    def __new__(cls, value: str, model: type[BaseModel], is_recurring: bool = False) -> Self:  # noqa: FBT001, FBT002
         """Create a new instance of the Enum with the given value and model."""
         obj = str.__new__(cls, value)
         obj.is_recurring = is_recurring

--- a/cumplo_common/utils/cache.py
+++ b/cumplo_common/utils/cache.py
@@ -1,3 +1,5 @@
+"""TTL cache utility with selective invalidation."""
+
 from logging import getLogger
 from typing import Any
 

--- a/cumplo_common/utils/constants.py
+++ b/cumplo_common/utils/constants.py
@@ -1,3 +1,5 @@
+"""Environment-sourced constants used across the library."""
+
 import json
 import os
 

--- a/cumplo_common/utils/currency.py
+++ b/cumplo_common/utils/currency.py
@@ -1,3 +1,5 @@
+"""Currency formatting utilities."""
+
 import babel.numbers
 
 from cumplo_common.models import Currency

--- a/cumplo_common/utils/text.py
+++ b/cumplo_common/utils/text.py
@@ -1,3 +1,5 @@
+"""Text cleaning and masking utilities."""
+
 import string
 import unicodedata
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,6 +26,7 @@ files = [
 
 [package.dependencies]
 idna = ">=2.8"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.32.0)"]
@@ -509,7 +510,10 @@ grpcio-status = [
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
     {version = ">=1.75.1,<2.0.0", optional = true, markers = "python_version >= \"3.14\" and extra == \"grpc\""},
 ]
-proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
+proto-plus = [
+    {version = ">=1.24.0,<2.0.0"},
+    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+]
 protobuf = ">=5.29.6,<8.0.0"
 requests = ">=2.33.0,<3.0.0"
 
@@ -669,7 +673,10 @@ grpcio = [
 grpcio-status = ">=1.51.3"
 opentelemetry-api = ">=1.27.0"
 opentelemetry-sdk = ">=1.27.0"
-proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
+proto-plus = [
+    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
+    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+]
 protobuf = ">=4.25.8,<8.0.0"
 
 [package.extras]
@@ -721,7 +728,10 @@ grpcio = [
     {version = ">=1.59.0,<2.0.0"},
     {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
 ]
-proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
+proto-plus = [
+    {version = ">=1.22.3,<2.0.0"},
+    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+]
 protobuf = ">=4.25.8,<8.0.0"
 
 [[package]]
@@ -1544,11 +1554,11 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
-markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
+markers = {main = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", dev = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -2124,5 +2134,5 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.13"
-content-hash = "c6495e965d1d942eaf9b37f98ff37b431815a5fba916cb92b426b19a9330de60"
+python-versions = "^3.12"
+content-hash = "814a65d30ab7c3fba4700b85516e04661b84ecf3de5b01d2253d6e29b1771127"

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,7 +26,6 @@ files = [
 
 [package.dependencies]
 idna = ">=2.8"
-typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.32.0)"]
@@ -510,10 +509,7 @@ grpcio-status = [
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
     {version = ">=1.75.1,<2.0.0", optional = true, markers = "python_version >= \"3.14\" and extra == \"grpc\""},
 ]
-proto-plus = [
-    {version = ">=1.24.0,<2.0.0"},
-    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-]
+proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
 protobuf = ">=5.29.6,<8.0.0"
 requests = ">=2.33.0,<3.0.0"
 
@@ -673,10 +669,7 @@ grpcio = [
 grpcio-status = ">=1.51.3"
 opentelemetry-api = ">=1.27.0"
 opentelemetry-sdk = ">=1.27.0"
-proto-plus = [
-    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
-    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-]
+proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
 protobuf = ">=4.25.8,<8.0.0"
 
 [package.extras]
@@ -728,10 +721,7 @@ grpcio = [
     {version = ">=1.59.0,<2.0.0"},
     {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
 ]
-proto-plus = [
-    {version = ">=1.22.3,<2.0.0"},
-    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-]
+proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
 protobuf = ">=4.25.8,<8.0.0"
 
 [[package]]
@@ -1554,11 +1544,11 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
+markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", dev = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -2134,5 +2124,5 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.12"
-content-hash = "814a65d30ab7c3fba4700b85516e04661b84ecf3de5b01d2253d6e29b1771127"
+python-versions = "^3.13"
+content-hash = "c6495e965d1d942eaf9b37f98ff37b431815a5fba916cb92b426b19a9330de60"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2125,4 +2125,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "958022b31d92d0f404e219e48f0fc3aaea52a18cc75fe2166ab4d534db58ab0b"
+content-hash = "c6495e965d1d942eaf9b37f98ff37b431815a5fba916cb92b426b19a9330de60"

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,7 +26,6 @@ files = [
 
 [package.dependencies]
 idna = ">=2.8"
-typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
 trio = ["trio (>=0.32.0)"]
@@ -65,6 +64,21 @@ files = [
 
 [package.extras]
 dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
+name = "basedpyright"
+version = "1.39.9"
+description = "static type checking for Python (but based)"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "basedpyright-1.39.9-py3-none-any.whl", hash = "sha256:6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c"},
+    {file = "basedpyright-1.39.9.tar.gz", hash = "sha256:32cbea5fc8273e89df3db20daea56cb7286e419ccdfdc479c64759d2dc071901"},
+]
+
+[package.dependencies]
+nodejs-wheel-binaries = ">=20.13.1"
 
 [[package]]
 name = "cachecontrol"
@@ -495,10 +509,7 @@ grpcio-status = [
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
     {version = ">=1.75.1,<2.0.0", optional = true, markers = "python_version >= \"3.14\" and extra == \"grpc\""},
 ]
-proto-plus = [
-    {version = ">=1.24.0,<2.0.0"},
-    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-]
+proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
 protobuf = ">=5.29.6,<8.0.0"
 requests = ">=2.33.0,<3.0.0"
 
@@ -658,10 +669,7 @@ grpcio = [
 grpcio-status = ">=1.51.3"
 opentelemetry-api = ">=1.27.0"
 opentelemetry-sdk = ">=1.27.0"
-proto-plus = [
-    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
-    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-]
+proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
 protobuf = ">=4.25.8,<8.0.0"
 
 [package.extras]
@@ -713,10 +721,7 @@ grpcio = [
     {version = ">=1.59.0,<2.0.0"},
     {version = ">=1.75.1,<2.0.0", markers = "python_version >= \"3.14\""},
 ]
-proto-plus = [
-    {version = ">=1.22.3,<2.0.0"},
-    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-]
+proto-plus = {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""}
 protobuf = ">=4.25.8,<8.0.0"
 
 [[package]]
@@ -1194,109 +1199,6 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-black (>=0.3.7) ; platform_python_i
 tox = ["tox"]
 
 [[package]]
-name = "librt"
-version = "0.13.0"
-description = "Mypyc runtime library"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-markers = "platform_python_implementation != \"PyPy\""
-files = [
-    {file = "librt-0.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34e47058fcc69a313293d6dee94216a4f30c929ae6f2476e58c5ba635aa639d5"},
-    {file = "librt-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbdd5b6509d0c2a8fe72cf494c299a61dbd58142a90a4190664ae159e4a7b547"},
-    {file = "librt-0.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e56ea4ee4df77585a6b5c138f6538680886024fa559f5b55bd14b12e98e67b2"},
-    {file = "librt-0.13.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f1f9cc4d09a46d9cb3c2063ae100629d3f52a6517c3c08c2f4c9828261883929"},
-    {file = "librt-0.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f125f5d46b20f89dc5587a55cc416b4ba2a5b2ffda36d048ee120e17598a653a"},
-    {file = "librt-0.13.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2608d3b39f9e0b4a66a130d9150c615cba40a5090d25eeeaa225e0e46de8c0ac"},
-    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9fd35e95ab5e45c3901d37110263c7db85a961110f5460588fe37f8c131f88a7"},
-    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5f31b0aa13c9b04370d4da6be1ab7779776b3a075cceb6747a39a4be85fe1e40"},
-    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0b795f5fc70fbbb787ceaf79bb3a0d627bcc33c53de51741755263ec406b775a"},
-    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36b306a623aaad96fe4b378692b54f9c0789fccd833b9851753d5fbf6138cfde"},
-    {file = "librt-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a3762e75fcac8c9e4dacaaf438bffd9003e2ca2c531b756f3c0035deefa674c8"},
-    {file = "librt-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:d63bae12a8aeb51380be3438e4dc4bd27354d0f8e19166b2f44e3e94d6f552dc"},
-    {file = "librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082"},
-    {file = "librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14"},
-    {file = "librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79"},
-    {file = "librt-0.13.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:9c5d02b89de5acd0379a51ec44a89476fb03df6145442e1c8ecd6bee2f91b176"},
-    {file = "librt-0.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7db9a3ff32ef5f7d1703d93831a3316cdf0b537de6a1cc03cc8fdd09b9194e89"},
-    {file = "librt-0.13.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3dbb2a31882456cadc7053378e81ad7ed7693db4ac9f98ab5f81ef034aa8ec9f"},
-    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c6014e3c80f9c1fe268ef8b0e0ef113bac672cc032f2f93866e7ddad4f3e663d"},
-    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:091b60a4d2174fc1ec5c34cdc0b72efb6224753d76b7da61ebeab7a191aec8bd"},
-    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:66cb1138f384a191a6d75f986064841fcfdc0cea98f7bd9c9ab9b38049917588"},
-    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17221a7569f8f292aa0014226e48aa25b8c2b08da18088cd230953d0ea0f9cd1"},
-    {file = "librt-0.13.0-cp311-cp311-win32.whl", hash = "sha256:fc67741da44c6eaa90e01eafb586bbba9b51eb5b6ed381ee6f5ae72eb3316d21"},
-    {file = "librt-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc99dfb62b23c9207c33d0be8a2e2af7a42e21e6ea388b380a0c948c7b88953b"},
-    {file = "librt-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:40ccd13c252d3fe473ffc8a57be7565abc8b64cf1b108344c859d5164f7f3e0c"},
-    {file = "librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0"},
-    {file = "librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5"},
-    {file = "librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9"},
-    {file = "librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b"},
-    {file = "librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03"},
-    {file = "librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e"},
-    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd"},
-    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348"},
-    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7"},
-    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82"},
-    {file = "librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3"},
-    {file = "librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa"},
-    {file = "librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1"},
-    {file = "librt-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a468951af16155824e88bdd8326ebe5bdb371f3ec0ac04642994b98201d914f3"},
-    {file = "librt-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae01d8512cc17079e53425635327dbf3f7ff57a42c00dec348bf79791c56444c"},
-    {file = "librt-0.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32c26893cd085c1efe83219e78d866da23fb20a066101b8f68210004361d224c"},
-    {file = "librt-0.13.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5929da1981a46bcf4b28b1b9499905f0ff58e2419da402a048234e9783acbc4b"},
-    {file = "librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9"},
-    {file = "librt-0.13.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:531b2df3e9fe96b1fcf73a6d165921e4656be5f58d631d384ebce344298368db"},
-    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:109b84a9edf69ad89dc1f66358659e14a031baca95e3e5b0060bd903ede8efd6"},
-    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1304368a3e7ffc3e9db986796cc5326fdb5943a3567ecc137cff318e4240c0e7"},
-    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e4f9b472e7d308d94b62c801982065661158c6ed02790d6c7ddb4337cea0f9c1"},
-    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f836c37478f167a81200d8c8b2c920a22224564bed2c23d7aeec760965c367a"},
-    {file = "librt-0.13.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:4000d961ff9598ac6ea603c6c836a5ed49bc205ade5fc378b998dfe1e2c36628"},
-    {file = "librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927"},
-    {file = "librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650"},
-    {file = "librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566"},
-    {file = "librt-0.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:25218d94b1d2cbc0ba1d8a3f9dc9af578d9646e5ed16443a70cde1dfdcce6d71"},
-    {file = "librt-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f26629539d4893c2957a16c41bb058e1e135c1f150f6a2e25ed047f64cf3f5c6"},
-    {file = "librt-0.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4517d47b2b8af26975a406fba7d314de9696d864252e0257c6ea90238cfe27f"},
-    {file = "librt-0.13.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f19e181de5b3a1148bb3420b8c4b0b0ea0fce6950099724ad151d6cea5acc180"},
-    {file = "librt-0.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22034924f5b42d5a56371cf271771bfeaabf235a7a8b6264bef2d20013f786c6"},
-    {file = "librt-0.13.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7897db4e95e22468bdda33d8e012ceacd0182abf001e6389d763f0def6286b9"},
-    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ce61b3746545029d4f5c17d6bd74b676254ad98433086c846ffb5e8fa73f007"},
-    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:46c330e82565962c761dbce7941be2cff7db674ee807455a8d0cadc5f9b759b0"},
-    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:375f5af8f99cbaa99dd293af986e3d57caabc9ba81a5d3f021603764854197a1"},
-    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9320d34c3376ae204b2cd176e8d4883a013934e0aef822f1aed9c536490c275d"},
-    {file = "librt-0.13.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:9af313c66157a69dc69ea0059a66961692250e0dc95af9c385a48ffb770a0d16"},
-    {file = "librt-0.13.0-cp314-cp314-win32.whl", hash = "sha256:f2a7253458e34f33543551394ae4fe104b497ec2a65ac266074de64c1df82e37"},
-    {file = "librt-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:a3dfe4edf10e8ed7e55b026a8bfc2c2a8704218b659cd4bffdf604fab966dc39"},
-    {file = "librt-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:68a5faee4bba381cb93b5961f684a514cf0053cb92308ff9c792c2fea0b174c6"},
-    {file = "librt-0.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a38fb81d8376dfa2f8963b265fec07637802b0d01e2a127c19c66cb070fb24f5"},
-    {file = "librt-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4c8d9bd5abce34b2e75edb3bf37ab0f34e49b1f915a40ae8468eb7c85bc5b46"},
-    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:387e2f1d27e89bffe0d3f520f0da0662c973fd607ca16c1808f8a5085419485e"},
-    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4f6db193d2e5e0ed60359b9a5a682cd67205d0d3b1e459a867dd4b5c4e7eaa7a"},
-    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d38604854e8d22faadf683ec6c02bb0f886e2ba56ef981a1c36ee275f21ea22"},
-    {file = "librt-0.13.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:371f7ce73026815dafd51c50ce38416e91428b28c4b2ec97cd39271164b0045c"},
-    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3aaedf52171bee90860704c560bc798fe83b76247df47568e0197e9b13c735a0"},
-    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:96bad8725a4f196a798366c25ce075d1f7543a4ec045ffc13e6a7ec095cdab04"},
-    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6bf6a559ffe4a93bbea6cf31ddf01a7fd9ba342ef51f27beb178e318b74acd61"},
-    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301067672387902c55f94b51d5022304b36c966ea9fe1f21caab99a9bef487c9"},
-    {file = "librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18"},
-    {file = "librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259"},
-    {file = "librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99"},
-    {file = "librt-0.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f442e3954b1addc759faae22a7c9a3f1e16d7d1db3f484279dc27d62e06968fa"},
-    {file = "librt-0.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e786428f291dd2d2f1cbfc0e0caa45a2e395fab0ad3e2c9314daa8873414390"},
-    {file = "librt-0.13.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21b7ac084f701a9cdff6139745a6620579d65a9379ac2d9d50a86368b109e63c"},
-    {file = "librt-0.13.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a6e556d6aba31c93dd97ce661d66614d2429c0a3923f9dc8f0af7e8df10223a4"},
-    {file = "librt-0.13.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3657346f867469e962549435aa05fd15330b1d6a92829f8e27988e194382d005"},
-    {file = "librt-0.13.0-cp39-cp39-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:791aa18a373b90da8ac3c44fc77544f33fdf53ae403acdce9b39f1c26b4a3b94"},
-    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d6fb0eaa108814581c4d3bfbd068c3fb6757812a81415008d1bae08267cca360"},
-    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a001519c315d5db40710f2665d32c4791f1d4779fc96a9423fd18d92c8b9ac7b"},
-    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:d9188caac26e47671b52836a5e2a49873a7fc11c673b0c122d22515f98bc14e1"},
-    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:05d96b80b95d3a2721b619f8982b8558848b04875bb4772fd54842b59f61dd97"},
-    {file = "librt-0.13.0-cp39-cp39-win32.whl", hash = "sha256:c3cd253cf32fe4f4662960d6bf7d55cb8be0c31a5d644a4d48aeafebaff3409a"},
-    {file = "librt-0.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:b15e26cc0fe622d0c67e98bee6ef6bc8f792e20ee3006aa12627a00463d9399f"},
-    {file = "librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781"},
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1421,89 +1323,6 @@ files = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.20.2"
-description = "Optional static typing for Python"
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "mypy-1.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cf5a4db6dca263010e2c7bff081c89383c72d187ba2cf4c44759aac970e2f0c4"},
-    {file = "mypy-1.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b0e817b518bff7facd7f85ea05b643ad8bdcce684cf29784987b0a7c8e1f997"},
-    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97d7b9a485b40f8ca425460e89bf1da2814625b2da627c0dcc6aa46c92631d14"},
-    {file = "mypy-1.20.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e1c12f6d2db3d78b909b5f77513c11eb7f2dd2782b96a3ab6dffc7d44575c99"},
-    {file = "mypy-1.20.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:89dce27e142d25ffbc154c1819383b69f2e9234dc4ed4766f42e0e8cb264ab5c"},
-    {file = "mypy-1.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:f376e37f9bf2a946872fc5fd1199c99310748e3c26c7a26683f13f8bdb756cbd"},
-    {file = "mypy-1.20.2-cp310-cp310-win_arm64.whl", hash = "sha256:6e2b469efd811707bc530fd1effef0f5d6eebcb7fe376affae69025da4b979a2"},
-    {file = "mypy-1.20.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4077797a273e56e8843d001e9dfe4ba10e33323d6ade647ff260e5cd97d9758c"},
-    {file = "mypy-1.20.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cdecf62abcc4292500d7858aeae87a1f8f1150f4c4dd08fb0b336ee79b2a6df3"},
-    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c566c3a88b6ece59b3d70f65bedef17304f48eb52ff040a6a18214e1917b3254"},
-    {file = "mypy-1.20.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0deb80d062b2479f2c87ae568f89845afc71d11bc41b04179e58165fd9f31e98"},
-    {file = "mypy-1.20.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bba9ad231e92a3e424b3e56b65aa17704993425bba97e302c832f9466bb85bac"},
-    {file = "mypy-1.20.2-cp311-cp311-win_amd64.whl", hash = "sha256:baf593f2765fa3a6b1ef95807dbaa3d25b594f6a52adcc506a6b9cb115e1be67"},
-    {file = "mypy-1.20.2-cp311-cp311-win_arm64.whl", hash = "sha256:20175a1c0f49863946ec20b7f63255768058ac4f07d2b9ded6a6b46cfb5a9100"},
-    {file = "mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b"},
-    {file = "mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4"},
-    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6"},
-    {file = "mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066"},
-    {file = "mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102"},
-    {file = "mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9"},
-    {file = "mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58"},
-    {file = "mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026"},
-    {file = "mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943"},
-    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517"},
-    {file = "mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15"},
-    {file = "mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee"},
-    {file = "mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f"},
-    {file = "mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330"},
-    {file = "mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30"},
-    {file = "mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924"},
-    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb"},
-    {file = "mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc"},
-    {file = "mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558"},
-    {file = "mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8"},
-    {file = "mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3"},
-    {file = "mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609"},
-    {file = "mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2"},
-    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c"},
-    {file = "mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744"},
-    {file = "mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6"},
-    {file = "mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec"},
-    {file = "mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382"},
-    {file = "mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563"},
-    {file = "mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665"},
-]
-
-[package.dependencies]
-librt = {version = ">=0.8.0", markers = "platform_python_implementation != \"PyPy\""}
-mypy_extensions = ">=1.0.0"
-pathspec = ">=1.0.0"
-typing_extensions = [
-    {version = ">=4.6.0", markers = "python_version < \"3.15\""},
-    {version = ">=4.14.0", markers = "python_version >= \"3.15\""},
-]
-
-[package.extras]
-dmypy = ["psutil (>=4.0)"]
-faster-cache = ["orjson"]
-install-types = ["pip"]
-mypyc = ["setuptools (>=50)"]
-native-parser = ["ast-serialize (>=0.1.1,<1.0.0)"]
-reports = ["lxml"]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
-    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
-]
-
-[[package]]
 name = "nh3"
 version = "0.3.6"
 description = "Python binding to Ammonia HTML sanitizer Rust crate"
@@ -1538,6 +1357,25 @@ files = [
     {file = "nh3-0.3.6-cp38-abi3-win_amd64.whl", hash = "sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10"},
     {file = "nh3-0.3.6-cp38-abi3-win_arm64.whl", hash = "sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21"},
     {file = "nh3-0.3.6.tar.gz", hash = "sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7"},
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.16.0"
+description = "unoffical Node.js package"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c"},
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51"},
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342"},
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd"},
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502"},
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03"},
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa"},
+    {file = "nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36"},
+    {file = "nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37"},
 ]
 
 [[package]]
@@ -1619,23 +1457,6 @@ files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
-
-[[package]]
-name = "pathspec"
-version = "1.1.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
-    {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
-]
-
-[package.extras]
-hyperscan = ["hyperscan (>=0.7)"]
-optional = ["typing-extensions (>=4)"]
-re2 = ["google-re2 (>=1.1)"]
 
 [[package]]
 name = "pluggy"
@@ -1723,7 +1544,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
-markers = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\""
+markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -2109,30 +1930,30 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
-version = "0.7.4"
+version = "0.8.6"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.7.4-py3-none-linux_armv6l.whl", hash = "sha256:a4919925e7684a3f18e18243cd6bea7cfb8e968a6eaa8437971f681b7ec51478"},
-    {file = "ruff-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfb365c135b830778dda8c04fb7d4280ed0b984e1aec27f574445231e20d6c63"},
-    {file = "ruff-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:63a569b36bc66fbadec5beaa539dd81e0527cb258b94e29e0531ce41bacc1f20"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d06218747d361d06fd2fdac734e7fa92df36df93035db3dc2ad7aa9852cb109"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0cea28d0944f74ebc33e9f934238f15c758841f9f5edd180b5315c203293452"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80094ecd4793c68b2571b128f91754d60f692d64bc0d7272ec9197fdd09bf9ea"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:997512325c6620d1c4c2b15db49ef59543ef9cd0f4aa8065ec2ae5103cedc7e7"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00b4cf3a6b5fad6d1a66e7574d78956bbd09abfd6c8a997798f01f5da3d46a05"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7dbdc7d8274e1422722933d1edddfdc65b4336abf0b16dfcb9dedd6e6a517d06"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e92dfb5f00eaedb1501b2f906ccabfd67b2355bdf117fea9719fc99ac2145bc"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3bd726099f277d735dc38900b6a8d6cf070f80828877941983a57bca1cd92172"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2e32829c429dd081ee5ba39aef436603e5b22335c3d3fff013cd585806a6486a"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:662a63b4971807623f6f90c1fb664613f67cc182dc4d991471c23c541fee62dd"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:876f5e09eaae3eb76814c1d3b68879891d6fde4824c015d48e7a7da4cf066a3a"},
-    {file = "ruff-0.7.4-py3-none-win32.whl", hash = "sha256:75c53f54904be42dd52a548728a5b572344b50d9b2873d13a3f8c5e3b91f5cac"},
-    {file = "ruff-0.7.4-py3-none-win_amd64.whl", hash = "sha256:745775c7b39f914238ed1f1b0bebed0b9155a17cd8bc0b08d3c87e4703b990d6"},
-    {file = "ruff-0.7.4-py3-none-win_arm64.whl", hash = "sha256:11bff065102c3ae9d3ea4dc9ecdfe5a5171349cdd0787c1fc64761212fc9cf1f"},
-    {file = "ruff-0.7.4.tar.gz", hash = "sha256:cd12e35031f5af6b9b93715d8c4f40360070b2041f81273d0527683d5708fce2"},
+    {file = "ruff-0.8.6-py3-none-linux_armv6l.whl", hash = "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3"},
+    {file = "ruff-0.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1"},
+    {file = "ruff-0.8.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76"},
+    {file = "ruff-0.8.6-py3-none-win32.whl", hash = "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764"},
+    {file = "ruff-0.8.6-py3-none-win_amd64.whl", hash = "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905"},
+    {file = "ruff-0.8.6-py3-none-win_arm64.whl", hash = "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162"},
+    {file = "ruff-0.8.6.tar.gz", hash = "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5"},
 ]
 
 [[package]]
@@ -2226,7 +2047,7 @@ version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
     {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
@@ -2303,5 +2124,5 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.12"
-content-hash = "bb8ce5a8093e8c84685ffb5e8a9e2790fae462ab7c779b8867d1b845509a71f3"
+python-versions = "^3.13"
+content-hash = "958022b31d92d0f404e219e48f0fc3aaea52a18cc75fe2166ab4d534db58ab0b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Cristobal Sfeir <hello@crisotbalsfeir.com>"]
 packages = [{ include = "cumplo_common" }]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.13"
 pydantic = "^2.1.1"
 arrow = "^1.2.3"
 firebase-admin = "^6.2.0"
@@ -25,8 +25,8 @@ google-auth-oauthlib = "^1.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.2"
-ruff = "^0.7.1"
-mypy = "^1.13.0"
+ruff = "^0.8.0"
+basedpyright = ">=1.0"
 keyring = "^25.2.1"
 keyrings-google-artifactregistry-auth = "^1.1.2"
 twine = "^6.1"
@@ -36,80 +36,61 @@ docformatter = "^1.7.5"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.mypy]
-python_version = "3.12"
-disallow_untyped_defs = true
-exclude = ".venv"
-
-[[tool.mypy.overrides]]
-module = [
-    "requests.*",
-    "pydantic.*",
-    "psycopg2.*",
-    "lxml.*",
-    "babel.*",
-    "bs4.*",
-    "functions_framework.*",
-    "firebase_admin.*",
-    "retry.*",
-    "starlette.*",
-    "google.cloud.pubsub.*",
-    "numpy_financial.*",
-    "cachetools.*",
-    "googleapiclient.*",
-]
-ignore_missing_imports = true
+[tool.pyright]
+pythonVersion = "3.13"
+typeCheckingMode = "standard"
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py313"
 preview = true
+fix = true
 
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    "ANN101", # Missing type annotation for self in method
-    "ANN102", # Missing type annotation for cls in method
-    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
-    "D100",   # Missing docstring in public module
-    "D107",   # Missing docstring in __init__
-    "D105",   # Missing docstring in magic method
-    "D212",   # Multi-line docstring summary should start at the second line
-    "D203",   # One blank line required before class docstring
-    "D101",   # Missing docstring in public class
-    "D104",   # Missing docstring in public package
-    "G004",   # Logging statement uses string formatting
-    "S113",   # Use of `requests` call without timeout
-    "DOC201", # Missing documentation for `return` in docstring
-    "COM812", # Missing trailing comma in a dictionary
-    "ISC001", # Implicit string concatenation
-    "CPY001", # Copying notice
-    "B019",   # LRU cache can generate memory leaks (when used without a maxsize)
-    "TD003",  # Missing issue link on the line following a TODO
-    "TD002",  # Missing author in TODO
-    "FIX002",  # Line contains TODO, consider resolving the issue
-    # =====
-    "PT011",  # ValueError is too broad, set the `match` parameter
-    "PT013",  # Incorrect import of `pytest`; use `import pytest` instead
-    "FBT003", # Boolean positional value in function call
-    "D102",   # Missing docstring in public method
-    "EM101",  # Exception must not use a string literal, assign to variable first
-    "DOC501", # Raised exception `ValueError` missing from docstring
-    "TRY003", # Avoid specifying long messages outside the exception class
-    "EM102",  # Exception must not use an f-string literal, assign to variable first
+  "ANN401",                              # allow typing.Any
+  "D100", "D101", "D102", "D105",        # module/class/method/magic-method docstrings not required
+  "D107",                                # no docstring required in __init__
+  "D212", "D203",                        # docstring-layout style choices
+  "D104",                                # no docstring required in public package
+  "FBT003",                              # boolean positional value (Pydantic Field defaults)
+  "G004",                                # allow f-strings in logging
+  "S113",                                # allow requests without explicit timeout
+  "DOC201", "DOC501", "DOC402",          # don't force return/raise/yield docs
+  "COM812", "ISC001",                    # defer to the formatter (avoid conflicts)
+  "CPY001",                              # no copyright header
+  "TRY003", "TRY300", "TRY301",          # relaxed exception-message/flow rules
+  "EM101", "EM102",                      # allow literals / f-strings in exceptions
+  "RUF012",                              # class vars without ClassVar
+  "S101",                                # allow assert
+  "BLE001",                              # allow broad except Exception
+  "TC006",                               # cast without quotes
+  "B904",                                # raise without from
+  "RUF005",                              # allow list concat
+  "TD002", "TD003", "FIX002", "FIX004",  # allow TODO/HACK comments
+  "RET503",                              # allow implicit None return
+  "ERA001",                              # allow commented-out code
+  "RUF018",                              # assert on walrus
+  "PGH003",                              # allow blanket pyright ignores
+  "PLW3201",                             # dunder method naming
+  "SLF001",                              # access to private attributes
+  "FAST002",                             # FastAPI dependency without Annotated (we are FastAPI)
+  "B008",                                # function call in defaults, e.g. Depends(...) (FastAPI)
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
-"tests/*" = ["S101", "PLR6301"]
+"tests/**" = ["ANN201", "ANN001", "ANN202", "D100", "PLC0415", "PLC2701", "ARG001"]
+"tests/**/*_test.py" = ["D101", "D103", "D102", "D205", "FBT001", "PLR2004", "PLR6301", "PT019", "RUF029"]
 
 [tool.ruff.format]
 docstring-code-format = true
 docstring-code-line-length = 120
 
 [tool.docformatter]
-pre-summary-newline = true # Ensures that multiline docstrings start on a new line.
-wrap-descriptions = 120    # Wraps descriptions at 114 characters, ensuring consistent line width.
-wrap-summaries = 120       # Wraps summary lines only if they exceed 114 characters.
-recursive = true           # Recursively formats all Python files in the specified directories.
-blank = true               # Adds a blank line before the end of multiline docstrings.
+pre-summary-newline = true
+wrap-descriptions = 120
+wrap-summaries = 120
+recursive = true
+blank = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ basedpyright = ">=1.0"
 keyring = "^25.2.1"
 keyrings-google-artifactregistry-auth = "^1.1.2"
 twine = "^6.1"
-docformatter = "^1.7.5"
+docformatter = "^1.7.8"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Cristobal Sfeir <hello@crisotbalsfeir.com>"]
 packages = [{ include = "cumplo_common" }]
 
 [tool.poetry.dependencies]
-python = "^3.13"
+python = "^3.12"
 pydantic = "^2.1.1"
 arrow = "^1.2.3"
 firebase-admin = "^6.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Cristobal Sfeir <hello@crisotbalsfeir.com>"]
 packages = [{ include = "cumplo_common" }]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.13"
 pydantic = "^2.1.1"
 arrow = "^1.2.3"
 firebase-admin = "^6.2.0"
@@ -92,3 +92,4 @@ wrap-descriptions = 120
 wrap-summaries = 120
 recursive = true
 blank = true
+exclude = [".venv"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,9 @@ fix = true
 select = ["ALL"]
 ignore = [
   "ANN401",                              # allow typing.Any
-  "D100", "D101", "D102", "D105",        # module/class/method/magic-method docstrings not required
   "D107",                                # no docstring required in __init__
   "D212", "D203",                        # docstring-layout style choices
   "D104",                                # no docstring required in public package
-  "FBT003",                              # boolean positional value (Pydantic Field defaults)
   "G004",                                # allow f-strings in logging
   "S113",                                # allow requests without explicit timeout
   "DOC201", "DOC501", "DOC402",          # don't force return/raise/yield docs

--- a/tests/unit/models/credentials_test.py
+++ b/tests/unit/models/credentials_test.py
@@ -1,5 +1,6 @@
 import pytest
 from cryptography.fernet import Fernet
+from pydantic import ValidationError
 
 from cumplo_common.models.credentials import Credentials
 from cumplo_common.utils.constants import PASSWORDS_ENCRYPTION_KEY
@@ -84,7 +85,7 @@ class TestCredentials:
 
     def test_invalid_credentials(self) -> None:
         """Test that invalid credentials raise appropriate errors."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             Credentials(
                 email="not_an_email",
                 password=PASSWORD,
@@ -93,7 +94,7 @@ class TestCredentials:
                 company_nin="1234567890",
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             Credentials(
                 email="test@example.com",
                 password="",
@@ -135,7 +136,7 @@ class TestCredentials:
         ]
 
         for email in invalid_emails:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValidationError):
                 Credentials(
                     email=email,
                     password=PASSWORD,

--- a/tests/unit/models/credentials_test.py
+++ b/tests/unit/models/credentials_test.py
@@ -85,7 +85,7 @@ class TestCredentials:
 
     def test_invalid_credentials(self) -> None:
         """Test that invalid credentials raise appropriate errors."""
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="email"):
             Credentials(
                 email="not_an_email",
                 password=PASSWORD,
@@ -94,7 +94,7 @@ class TestCredentials:
                 company_nin="1234567890",
             )
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="password"):
             Credentials(
                 email="test@example.com",
                 password="",
@@ -136,7 +136,7 @@ class TestCredentials:
         ]
 
         for email in invalid_emails:
-            with pytest.raises(ValidationError):
+            with pytest.raises(ValidationError, match="email"):
                 Credentials(
                     email=email,
                     password=PASSWORD,


### PR DESCRIPTION
## Summary

- Switches `pyproject.toml` to `ruff select = ["ALL"]` with a curated ignore list, `preview = true`, `target-version = "py313"`, and `basedpyright` replacing mypy; adds `[tool.pyright]` block and `[tool.docformatter]` config.
- Adds `format` Makefile target (ruff + docformatter apply fixes), updates `lint` to check-only (ruff + basedpyright + docformatter), and adds `check` (lint + pytest).
- Updates CI (`ci.yml`) to Python 3.13, drops individual Ruff/Mypy steps in favour of a single `make lint` call.
- Fixes all 72 rule violations across the codebase (D-series docstrings, FBT003 boolean Field defaults, PT011 pytest.raises match params); 0 basedpyright errors; docformatter clean; 23/23 pytest passing.
- Updates `CLAUDE.md` to document the new tooling commands and before-committing checklist.

## Test plan

- [ ] CI passes: `make lint` (ruff, basedpyright, docformatter) + pytest on this PR branch
- [ ] `make format` + `make lint` locally: 0 violations (verified pre-push)
- [ ] 23/23 pytest tests pass (verified pre-push)
- [ ] No mypy dependency left in `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)